### PR TITLE
Update FrontendMetadataEditForm.swift

### DIFF
--- a/Sources/FrontendModule/Forms/FrontendMetadataEditForm.swift
+++ b/Sources/FrontendModule/Forms/FrontendMetadataEditForm.swift
@@ -76,7 +76,7 @@ final class FrontendMetadataModelEditForm: ModelForm {
         output.status = Metadata.Status(rawValue: statusId.value!)!
         output.feedItem = feedItem.value ?? false
         output.filters = filters.values
-        output.date = Application.Config.dateFormatter().date(from: date.value!)!
+        output.date = Application.Config.dateFormatter().date(from: date.value!) ?? Date()
         output.title = title.value?.emptyToNil
         output.excerpt = excerpt.value?.emptyToNil
         output.canonicalUrl = canonicalUrl.value?.emptyToNil


### PR DESCRIPTION
Hello @tib,

came across this bug when editing the date for a Post and updating the metadata.  

I created my POST using the API, so the date is NULL as I cannot set it in the blog API. End result, you cannot edit the POST date afterward. Until we add the data to the Blog API, this will fix the issue as it raising an fatalError on date as it is not initialise.. Having a fall back value fix the issue.

Another way to test it, update your DB, table `frontend_metadatas`, remove the date from a Post. (I guess it will actually be the same on anything, categories, etc... Haven't tried that.

Kind Regards,

DEnis  